### PR TITLE
Stop crash if errorDrawable is null

### DIFF
--- a/android/src/main/java/com/mmmgbhutta/reactnative/wallpapermanager/ManageWallpaperModule.java
+++ b/android/src/main/java/com/mmmgbhutta/reactnative/wallpapermanager/ManageWallpaperModule.java
@@ -258,7 +258,11 @@ public class ManageWallpaperModule extends ReactContextBaseJavaModule {
             @Override
             public void onLoadFailed(Drawable errorDrawable) {
                 // Do nothing.
-                sendMessage("error", "Set Wallpaper Failed：" + errorDrawable.toString(), source);
+                String errorMessage = "Set Wallpaper Failed：Image not loaded";
+                if(errorDrawable != null) {
+                    errorMessage = "Set Wallpaper Failed：" + errorDrawable.toString();
+                }
+                sendMessage("error", errorMessage, source);
             }
         };
     }


### PR DESCRIPTION
# Overview
I noticed that in cases where `errorDrawable` is null in `onLoadFailed` a crash would occur.

This change will check for this and return a generic string error preventing the crash and allowing the error to be handled app-side
